### PR TITLE
Fix mislabeling in UI and wrong pid numbers

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -568,6 +568,7 @@ var publicMethods = {
 
 		_shout('firstUpdate');
 		_currentItemIndex = _currentItemIndex || _options.index || 0;
+		_currentItemIndex = parseInt(_currentItemIndex);
 		// validate index
 		if( isNaN(_currentItemIndex) || _currentItemIndex < 0 || _currentItemIndex >= _getNumItems() ) {
 			_currentItemIndex = 0;


### PR DESCRIPTION
In UI and URL hash generation (currentItemIndex + 1) were adding "1" as a symbol at the end of the string instead of incrementing the integer value