### PR TITLE
Fixed a preload bug at the seam

### DIFF
--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -259,16 +259,14 @@ _registerModule('Controller', {
 
 				var p = _options.preload,
 					isNext = diff === null ? true : (diff >= 0),
-					preloadBefore = Math.min(p[0], _getNumItems() ),
-					preloadAfter = Math.min(p[1], _getNumItems() ),
+					numItems = _getNumItems(),
+					preloadBefore = Math.min(p[0], numItems),
+					preloadAfter = Math.min(p[1], numItems),
 					i;
 
+				for (i=-preloadBefore; i<=preloadAfter; i++) {
 
-				for(i = 1; i <= (isNext ? preloadAfter : preloadBefore); i++) {
-					self.lazyLoadItem(_currentItemIndex+i);
-				}
-				for(i = 1; i <= (isNext ? preloadBefore : preloadAfter); i++) {
-					self.lazyLoadItem(_currentItemIndex-i);
+					self.lazyLoadItem( (numItems + _currentItemIndex + i) % numItems );
 				}
 			});
 


### PR DESCRIPTION
This patch fixes a bug at the seam, e.g. when the current item is at the first or last slide, where the preloader attempts to to load an item whose index is either negative or is greater than the number of items.

Soves issue #1176 -- This solution is better than the one I proposed in #1177