### PR TITLE
Tiny issue with pswp__counter on RTL sites

### DIFF
--- a/dist/default-skin/default-skin.css
+++ b/dist/default-skin/default-skin.css
@@ -254,7 +254,8 @@ a.pswp__share--download:hover {
   line-height: 44px;
   color: #FFF;
   opacity: 0.75;
-  padding: 0 10px; }
+  padding: 0 10px;
+  direction: ltr; }
 
 /*
 	


### PR DESCRIPTION
Today in RTL you get :
12/1.....12/2...

But for numbers it should be from left to right:
1/12....2/12....